### PR TITLE
Fix NAT DNS on Virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,10 @@ IMAGE_NAME = "bento/ubuntu-20.04"
 N = 3
 
 Vagrant.configure("2") do |config|
+    config.vm.provider :virtualbox do |vb|
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    end
+    
     config.ssh.insert_key = false
 
     config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
I was unable to get the provisioning via Ansible to work properly until discovering DNS was not properly passed through NAT by Virtualbox without the section I have suggested in this PR.

See https://serverfault.com/questions/453185/vagrant-virtualbox-dns-10-0-2-3-not-working for more info on how I resolved it.